### PR TITLE
Add "Replace ALL" option to Quick Fix menu

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,6 +17,7 @@ interface WokeSettings {
   customArgs: string[];
 }
 
+
 enum RunTrigger {
   onSave,
   onType,
@@ -139,18 +140,54 @@ export class WokeProvider implements vscode.CodeActionProvider {
 
     for (const diagnostic of context.diagnostics) {
       this.alternatives.get(diagnostic.code).forEach((alt: string) => {
-        actions.push(this.createFix(document, diagnostic.range, alt));
+        actions.push(this.createFix(document, diagnostic.range, alt));        
       });
     }
+    for (const diagnostic of context.diagnostics) {
+      this.alternatives.get(diagnostic.code).forEach((alt: string) => {
+        const action = this.createFixAll(document, diagnostic.code, alt)
+        if (action !== undefined) {
+          actions.push(action);    
+        }        
+      });
+    }
+    
     return actions;
   }
-
+  
+  private getFixEdit(msg: string): vscode.CodeAction {
+    const fix: vscode.CodeAction = new vscode.CodeAction(msg, vscode.CodeActionKind.QuickFix);
+    fix.edit = new vscode.WorkspaceEdit();      
+    return fix
+  }
+  
+  
   private createFix(document: vscode.TextDocument, range: vscode.Range, replacement: string): vscode.CodeAction {
-    const msg = `[woke] Click to replace with '${replacement}'`;
-    const fix = new vscode.CodeAction(msg, vscode.CodeActionKind.QuickFix);
-    fix.edit = new vscode.WorkspaceEdit();
-    fix.edit.replace(document.uri, range, replacement);
+    const fix = this.getFixEdit(`[woke] Click to replace with '${replacement}'`);
+    fix?.edit?.replace(document.uri, range, replacement);
     return fix;
+  }
+
+  private createFixAll(document: vscode.TextDocument, code: any, replacement: string): vscode.CodeAction | undefined{
+    const textEdits = new Array<vscode.TextEdit>()
+    const diagnosticCollection = this.diagnosticCollection.get(document.uri)
+    if (diagnosticCollection !== undefined) {
+      for (const diagnostic of diagnosticCollection) {
+        if (diagnostic.code == code) {
+          textEdits.push(new vscode.TextEdit(diagnostic.range, replacement))
+        }
+      }
+      
+      if (textEdits.length > 1) {
+        const fix = this.getFixEdit(`[woke] Click to replace ALL with '${replacement}'`);
+        fix?.edit?.set(document.uri, textEdits); 
+        return fix;  
+      }
+
+    }
+    
+    return undefined;
+    
   }
 
   private showMessage(msg: string, severity: MessageSeverity): void {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -146,8 +146,8 @@ export class WokeProvider implements vscode.CodeActionProvider {
       this.alternatives.get(diagnostic.code).forEach((alt: string) => {
         const action = this.createFixAll(document, diagnostic.code, alt);
         if (action !== undefined) {
-          actions.push(action);    
-        }        
+          actions.push(action);
+        }
       });
     }
     
@@ -156,7 +156,7 @@ export class WokeProvider implements vscode.CodeActionProvider {
   
   private getFixEdit(msg: string): vscode.CodeAction {
     const fix: vscode.CodeAction = new vscode.CodeAction(msg, vscode.CodeActionKind.QuickFix);
-    fix.edit = new vscode.WorkspaceEdit();      
+    fix.edit = new vscode.WorkspaceEdit();
     return fix;
   }
   
@@ -179,8 +179,8 @@ export class WokeProvider implements vscode.CodeActionProvider {
       
       if (textEdits.length > 1) {
         const fix = this.getFixEdit(`[woke] Click to replace ALL with '${replacement}'`);
-        fix?.edit?.set(document.uri, textEdits); 
-        return fix;  
+        fix?.edit?.set(document.uri, textEdits);
+        return fix;
       }
 
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -150,7 +150,6 @@ export class WokeProvider implements vscode.CodeActionProvider {
         }
       });
     }
-    
     return actions;
   }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -153,14 +153,13 @@ export class WokeProvider implements vscode.CodeActionProvider {
     
     return actions;
   }
-  
+
   private getFixEdit(msg: string): vscode.CodeAction {
     const fix: vscode.CodeAction = new vscode.CodeAction(msg, vscode.CodeActionKind.QuickFix);
     fix.edit = new vscode.WorkspaceEdit();
     return fix;
   }
-  
-  
+
   private createFix(document: vscode.TextDocument, range: vscode.Range, replacement: string): vscode.CodeAction {
     const fix = this.getFixEdit(`[woke] Click to replace with '${replacement}'`);
     fix?.edit?.replace(document.uri, range, replacement);
@@ -176,17 +175,15 @@ export class WokeProvider implements vscode.CodeActionProvider {
           textEdits.push(new vscode.TextEdit(diagnostic.range, replacement));
         }
       }
-      
+
       if (textEdits.length > 1) {
         const fix = this.getFixEdit(`[woke] Click to replace ALL with '${replacement}'`);
         fix?.edit?.set(document.uri, textEdits);
         return fix;
       }
-
     }
-    
+
     return undefined;
-    
   }
 
   private showMessage(msg: string, severity: MessageSeverity): void {
@@ -213,7 +210,6 @@ export class WokeProvider implements vscode.CodeActionProvider {
 
   private async runWoke(textDocument: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
     return new Promise<vscode.Diagnostic[]>((resolve) => {
-
       const diagnostics: vscode.Diagnostic[] = [];
       const useBufferArgs = textDocument.isUntitled || this.settings.trigger !== RunTrigger.onSave;
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,7 +17,6 @@ interface WokeSettings {
   customArgs: string[];
 }
 
-
 enum RunTrigger {
   onSave,
   onType,
@@ -140,12 +139,12 @@ export class WokeProvider implements vscode.CodeActionProvider {
 
     for (const diagnostic of context.diagnostics) {
       this.alternatives.get(diagnostic.code).forEach((alt: string) => {
-        actions.push(this.createFix(document, diagnostic.range, alt));        
+        actions.push(this.createFix(document, diagnostic.range, alt));
       });
     }
     for (const diagnostic of context.diagnostics) {
       this.alternatives.get(diagnostic.code).forEach((alt: string) => {
-        const action = this.createFixAll(document, diagnostic.code, alt)
+        const action = this.createFixAll(document, diagnostic.code, alt);
         if (action !== undefined) {
           actions.push(action);    
         }        
@@ -158,7 +157,7 @@ export class WokeProvider implements vscode.CodeActionProvider {
   private getFixEdit(msg: string): vscode.CodeAction {
     const fix: vscode.CodeAction = new vscode.CodeAction(msg, vscode.CodeActionKind.QuickFix);
     fix.edit = new vscode.WorkspaceEdit();      
-    return fix
+    return fix;
   }
   
   
@@ -169,12 +168,12 @@ export class WokeProvider implements vscode.CodeActionProvider {
   }
 
   private createFixAll(document: vscode.TextDocument, code: any, replacement: string): vscode.CodeAction | undefined{
-    const textEdits = new Array<vscode.TextEdit>()
-    const diagnosticCollection = this.diagnosticCollection.get(document.uri)
+    const textEdits = new Array<vscode.TextEdit>();
+    const diagnosticCollection = this.diagnosticCollection.get(document.uri);
     if (diagnosticCollection !== undefined) {
       for (const diagnostic of diagnosticCollection) {
-        if (diagnostic.code == code) {
-          textEdits.push(new vscode.TextEdit(diagnostic.range, replacement))
+        if (diagnostic.code === code) {
+          textEdits.push(new vscode.TextEdit(diagnostic.range, replacement));
         }
       }
       


### PR DESCRIPTION
Adds "[woke] Click to replace ALL with ..." option to the Quick Fix menu to replace all occurrences of the violation with the selected alternative.