### PR TITLE
Capitalize replacement if needed

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -147,11 +147,11 @@ export class WokeProvider implements vscode.CodeActionProvider {
 
   private capitalizeReplacementIfNeeded(document: vscode.TextDocument, range: vscode.Range, replacement: string): string {
     const text = document.getText(range);
-    let caseAwareReplacement: string = replacement
+    let caseAwareReplacement: string = replacement;
     if (text.length > 0) {
-      const firstCharacter = text[0]
-      if (firstCharacter == firstCharacter.toUpperCase()) {
-        caseAwareReplacement = replacement[0].toUpperCase()
+      const firstCharacter = text[0];
+      if (firstCharacter === firstCharacter.toUpperCase()) {
+        caseAwareReplacement = replacement[0].toUpperCase();
         if (replacement.length > 1) {
           caseAwareReplacement += replacement.substring(1);
         } 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -145,11 +145,26 @@ export class WokeProvider implements vscode.CodeActionProvider {
     return actions;
   }
 
+  private capitalizeReplacementIfNeeded(document: vscode.TextDocument, range: vscode.Range, replacement: string): string {
+    const text = document.getText(range);
+    let caseAwareReplacement: string = replacement
+    if (text.length > 0) {
+      const firstCharacter = text[0]
+      if (firstCharacter == firstCharacter.toUpperCase()) {
+        caseAwareReplacement = replacement[0].toUpperCase()
+        if (replacement.length > 1) {
+          caseAwareReplacement += replacement.substring(1);
+        } 
+      }
+    }
+    return caseAwareReplacement;
+  }
+  
   private createFix(document: vscode.TextDocument, range: vscode.Range, replacement: string): vscode.CodeAction {
     const msg = `[woke] Click to replace with '${replacement}'`;
     const fix = new vscode.CodeAction(msg, vscode.CodeActionKind.QuickFix);
     fix.edit = new vscode.WorkspaceEdit();
-    fix.edit.replace(document.uri, range, replacement);
+    fix.edit.replace(document.uri, range, this.capitalizeReplacementIfNeeded(document, range, replacement));
     return fix;
   }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -163,12 +163,12 @@ export class WokeProvider implements vscode.CodeActionProvider {
         caseAwareReplacement = replacement[0].toUpperCase();
         if (replacement.length > 1) {
           caseAwareReplacement += replacement.substring(1);
-        } 
+        }
       }
     }
     return caseAwareReplacement;
   }
-  
+
   private getFixEdit(msg: string): vscode.CodeAction {
     const fix: vscode.CodeAction = new vscode.CodeAction(msg, vscode.CodeActionKind.QuickFix);
     fix.edit = new vscode.WorkspaceEdit();

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -179,7 +179,7 @@ export class WokeProvider implements vscode.CodeActionProvider {
     const capitalizedReplacement = this.capitalizeReplacementIfNeeded(document, range, replacement);
     const msg = `[woke] Click to replace with '${capitalizedReplacement}'`;
     const fix = this.getFixEdit(msg);
-    fix?.edit?.replace(document.uri, range, replacement);
+    fix?.edit?.replace(document.uri, range, capitalizedReplacement);
     return fix;
   }
 


### PR DESCRIPTION
The Quick Fix "replace" feature respects the capitalization of the term being replaced. 
For example "Badword is in the sentence" -> Click to replace with "good word" -> "Good word is in the sentence"